### PR TITLE
Add more properties to eventually configure verbosity_level_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,24 @@ are logging.
 The console logger overrides the default `monolog.handler` in order to allow setting
 a custom log file. If defined, it will use `monolog.console_logfile`, and if not, it
 will fall back to `monolog.logfile`.
+
+The minimum logging level at which this handler will be triggered depends on the
+verbosity setting of the console output. The default mapping is:
+ - `OutputInterface::VERBOSITY_NORMAL` will show all `WARNING` and higher logs
+ - `OutputInterface::VERBOSITY_VERBOSE` (`-v`) will show all `NOTICE` and higher logs
+ - `OutputInterface::VERBOSITY_VERY_VERBOSE` (`-vv`) will show all `INFO` and higher logs
+ - `OutputInterface::VERBOSITY_DEBUG` (`-vvv`) will show all DEBUG and higher logs, i.e. all logs
+ 
+This mapping can be customized with the `logger.console_logger.handler.verbosity_level_map` constructor parameter:
+
+```php
+$app->register(new ConsoleLoggerServiceProvider(), [
+    'logger.console_logger.handler.verbosity_level_map' => array(
+        OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
+        OutputInterface::VERBOSITY_NORMAL => Logger::INFO,
+        OutputInterface::VERBOSITY_VERBOSE => Logger::NOTICE,
+        OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO,
+        OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
+    ),
+]);
+```


### PR DESCRIPTION
Needed to make [ConsoleHandler](https://api.symfony.com/3.1/Symfony/Bridge/Monolog/Handler/ConsoleHandler.html) `$verbosityLevelMap` configurable with the intention to set default log level to `INFO`.

```php
        $app->register(new ConsoleLoggerServiceProvider(), [
            'logger.console_logger.handler.verbosity_level_map' => [
                OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
                OutputInterface::VERBOSITY_NORMAL => Logger::INFO, // <---
                OutputInterface::VERBOSITY_VERBOSE => Logger::NOTICE,
                OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO,
                OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
            ],
        ]);
```

added more options to be able to override without changes to service provider.

backward incompatible changes (will release as 2.0):
- dropped `$app['logger.console_format']` & `$app['logger.console_date_format']`, override in `$app['logger.console_logger.formatter.options']` if needed