### PR TITLE
Fix symfony/monolog-bridge dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
 		"monolog/monolog": "^1.23",
 		"pimple/pimple": "^3.0",
 		"symfony/console": "^2.8|^3.0|^4.0|^5.0",
-		"symfony/monolog-bridge": "^2.8|^3.0|^4.0|^5.0"
+		"symfony/monolog-bridge": "^3.3|^4.0|^5.0"
 	}
 }


### PR DESCRIPTION
symfony/monolog-bridge 3.3 is first version supporting array of options to ConsoleFormatter